### PR TITLE
Parse JSON on message bodies

### DIFF
--- a/lib/worker.js
+++ b/lib/worker.js
@@ -8,13 +8,25 @@ module.exports = settings => {
 
   return (message, done) => {
 
-    const body = message.Body;
-    if (!body.model || !resolvers[body.model]) {
-      return done(new Error(`Unknown model type: ${body.model}`));
-    }
-    resolvers[body.model](models, body)
+    Promise.resolve()
+      .then(() => {
+        return JSON.parse(message.Body);
+      })
+      .then(body => {
+        if (!body.model || !resolvers[body.model]) {
+          throw new Error(`Unknown model type: ${body.model}`);
+        }
+        return body;
+      })
+      .then(body => {
+        console.log(body);
+        return resolvers[body.model](models, body);
+      })
       .then(() => done())
-      .catch(e => done(e));
+      .catch(e => {
+        console.log(e);
+        done(e);
+      });
 
   };
 


### PR DESCRIPTION
The message body is a JSON encoded string, not an object, so it needs to be parsed before trying to work with it.