### PR TITLE
Prevent resolver from crashing if SQS queue is not present

### DIFF
--- a/index.js
+++ b/index.js
@@ -16,4 +16,10 @@ const app = Consumer.create({
   sqs
 });
 
+app.on('error', error => {
+  console.error(error.message);
+  app.stop();
+  setTimeout(() => app.start(), 1000);
+});
+
 app.start();


### PR DESCRIPTION
Queue should attempt to reconnect periodically instead of permanently crashing is SQS is not available.