### PR TITLE
Associate login emails with profile emails

### DIFF
--- a/lib/resolvers/profile.js
+++ b/lib/resolvers/profile.js
@@ -5,8 +5,7 @@ module.exports = ({ models }) => ({ action, data, id }) => {
   const { Profile } = models;
 
   if (action === 'create') {
-    return Profile.query().where({ email: data.email })
-      .then(profiles => profiles[0])
+    return Profile.query().findOne({ email: data.email })
       .then(profile => {
         if (profile) {
           return Profile.query()

--- a/lib/resolvers/profile.js
+++ b/lib/resolvers/profile.js
@@ -1,11 +1,26 @@
 const resolver = require('./base-resolver');
 
 module.exports = ({ models }) => ({ action, data, id }) => {
-  return resolver({ Model: models.Profile, action, data, id })
-    .then(result => {
-      if (action === 'create') {
+
+  const { Profile } = models;
+
+  if (action === 'create') {
+    return Profile.query().where({ email: data.email })
+      .then(profiles => profiles[0])
+      .then(profile => {
+        if (profile) {
+          return Profile.query()
+            .patchAndFetchById(profile.id, { userId: data.userId });
+        }
+        return Profile.query()
+          .insert(data)
+          .returning('*');
+      })
+      .then(result => {
         result.changedBy = result.id;
-      }
-      return result;
-    });
+        return result;
+      });
+  }
+
+  return resolver({ Model: models.Profile, action, data, id });
 };


### PR DESCRIPTION
If a person logs in with no profile, but a profile exists with the same email as their login then associate that profile rather than trying to create a new one (which will fail due to uniqueness constraints on email addresses)