### PR TITLE
Always resolve messages

### DIFF
--- a/lib/worker.js
+++ b/lib/worker.js
@@ -29,7 +29,6 @@ module.exports = settings => {
             return resolvers[body.model]({ models, jwt, emailer })(body);
           })
           .then(changelog => {
-            console.log(`Adding ${message.MessageId} to changelog`);
 
             let establishmentId = body.establishmentId || (body.data && body.data.establishmentId) || null;
 
@@ -55,8 +54,8 @@ module.exports = settings => {
       })
       .then(() => done())
       .catch(e => {
-        console.log(e);
-        done(e);
+        console.error(e);
+        done();
       });
 
   };


### PR DESCRIPTION
At the moment failed messages stay on the queue and are periodically re-processed. This is bad.

It means that the client will have already erroed out, and will likely attempt to resend the same or similar message. This will result in duplicate messages on the queue, and so in all likelihood, more errors.

This in turn makes a mess of the logs, and can potentially have unexpected side effects if for whatever reason a previously failed message becomes deliverable.

The best thing to do is to discard failed messages (by treating them as processed) but by virtue of not having written to the changelog, the client will throw.

tl;dr - it's better to know the thing hasn't been done if it errors, than for it to maybe happen at some unknown point in the future.