### PR TITLE
Use transactions for profile updates

### DIFF
--- a/lib/resolvers/profile.js
+++ b/lib/resolvers/profile.js
@@ -21,5 +21,5 @@ module.exports = ({ models }) => ({ action, data, id }, transaction) => {
       });
   }
 
-  return resolver({ Model: models.Profile, action, data, id });
+  return resolver({ Model: models.Profile, action, data, id }, transaction);
 };


### PR DESCRIPTION
The transaction parameter wasn't being passed through to the base resolver when processing profile changes. This causes sporadic errors in database connections.