### PR TITLE
Handle first patch of a new project

### DIFF
--- a/lib/resolvers/project-version.js
+++ b/lib/resolvers/project-version.js
@@ -1,6 +1,6 @@
 const resolver = require('./base-resolver');
 const { applyChange } = require('deep-diff');
-const { cloneDeep, castArray } = require('lodash');
+const { cloneDeep, castArray, get } = require('lodash');
 
 const applyPatches = (source, patches) => {
   const patched = cloneDeep(source);
@@ -34,7 +34,8 @@ module.exports = ({ models }) => ({ action, data, id }, transaction) => {
         return Project.query(transaction).findById(version.projectId)
           .then(project => {
             if (project.status === 'inactive') {
-              return project.$query(transaction).patchAndFetch({ title: version.data.title });
+              const title = get(version, 'data.title');
+              return project.$query(transaction).patchAndFetch({ title });
             }
           })
           .then(() => version);


### PR DESCRIPTION
If a brand new project is created then the `data` field is null, and trying to read the title throws an error.

Instead use `lodash.get` to read the title so it doesn't fail.