### PR TITLE
pil should update data on a grant action

### DIFF
--- a/lib/resolvers/pil.js
+++ b/lib/resolvers/pil.js
@@ -5,12 +5,14 @@ module.exports = ({ models }) => ({ action, data, id }, transaction) => {
   const { PIL } = models;
 
   if (action === 'grant') {
-    return PIL.query(transaction)
-      .patchAndFetchById(id, {
+    return Promise.resolve()
+      .then(() => resolver({ Model: models.PIL, action: 'update', data, id }, transaction))
+      .then(() => PIL.query(transaction).findById(id))
+      .then(pil => pil.$query(transaction).patchAndFetch({
         status: 'active',
-        issueDate: new Date().toISOString(),
-        licenceNumber: generateLicenceNumber()
-      });
+        issueDate: pil.issueDate || new Date().toISOString(),
+        licenceNumber: pil.licenceNumber || generateLicenceNumber()
+      }));
   }
 
   return resolver({ Model: models.PIL, action, data, id }, transaction);


### PR DESCRIPTION
Previously a user would add procedures to an inactive PIL then apply for that PIL to be granted - this does not scale to PIL amends as the data cannot be mutated on an active PIL. Instead always update data on a resolved grant action