### PR TITLE
Actually run scheduled tasks

### DIFF
--- a/lib/utils/scheduler.js
+++ b/lib/utils/scheduler.js
@@ -6,7 +6,7 @@ module.exports = (interval = 'day') => {
   const tasks = [];
 
   setInterval(() => {
-    if (lastCall && lastCall.isBefore(moment(), interval)) {
+    if (!lastCall || lastCall.isBefore(moment(), interval)) {
       tasks.forEach(task => task());
       lastCall = moment();
     }


### PR DESCRIPTION
The check that `lastCall` exists in the task runner means it never actually runs because it's initialised as undefined.