### PR TITLE
Only expire active projects

### DIFF
--- a/lib/tasks/expire.js
+++ b/lib/tasks/expire.js
@@ -4,5 +4,5 @@ module.exports = ({ Project }) => () => {
   return Project.query()
     .update({ status: 'expired' })
     .where('expiryDate', '<=', moment().toISOString())
-    .where('status', '!=', 'expired');
+    .where('status', 'active');
 };


### PR DESCRIPTION
Projects with a status of `revoked` shouldn't be changed to `expired`.