### PR TITLE
Don't save complete project versions to changelog

### DIFF
--- a/lib/resolvers/project-version.js
+++ b/lib/resolvers/project-version.js
@@ -63,7 +63,7 @@ module.exports = ({ models }) => ({ action, data, id }, transaction) => {
               return project.$query(transaction).patchAndFetch({ title });
             }
           })
-          .then(() => version);
+          .then(() => (action === 'patch' ? data : {}));
       });
   }
   return resolver({ Model: ProjectVersion, action, data, id }, transaction);


### PR DESCRIPTION
They get very big very quickly when they're being saved every few seconds.

Instead save only the patch data for patch updates.