### PR TITLE
Handle empty species on PILs

### DIFF
--- a/lib/resolvers/pil.js
+++ b/lib/resolvers/pil.js
@@ -6,6 +6,9 @@ module.exports = ({ models }) => ({ action, data, id }, transaction) => {
   const { PIL } = models;
 
   if (action === 'grant') {
+    if (Array.isArray(data.species) && data.species.length === 0) {
+      data.species = null;
+    }
     return Promise.resolve()
       .then(() => resolver({ Model: models.PIL, action: 'update', data, id }, transaction))
       .then(() => PIL.query(transaction).findById(id))

--- a/lib/worker.js
+++ b/lib/worker.js
@@ -49,6 +49,7 @@ module.exports = settings => {
       })
       .then(() => done())
       .catch(e => {
+        console.error(message.Body);
         console.error(e);
         done();
       });


### PR DESCRIPTION
If a PIL application makes it through with `species: []` then revert it to `null`.

Also log the actual message when one fails.