### PR TITLE
Add an action on a project to submit draft

### DIFF
--- a/lib/resolvers/project.js
+++ b/lib/resolvers/project.js
@@ -42,6 +42,7 @@ module.exports = ({ models }) => ({ action, data, id, meta }, transaction) => {
       .orderBy('createdAt', 'desc')
       .first()
       .then(version => version.$query(transaction).patchAndFetch({ status: 'submitted' }))
+      .then(() => Project.query(transaction).findById(id));
   }
 
   if (action === 'grant') {

--- a/lib/resolvers/project.js
+++ b/lib/resolvers/project.js
@@ -36,6 +36,14 @@ module.exports = ({ models }) => ({ action, data, id, meta }, transaction) => {
     return fork();
   }
 
+  if (action === 'submit-draft') {
+    return ProjectVersion.query(transaction)
+      .where({ projectId: id, status: 'draft' })
+      .orderBy('createdAt', 'desc')
+      .first()
+      .then(version => version.$query(transaction).patchAndFetch({ status: 'submitted' }))
+  }
+
   if (action === 'grant') {
     return ProjectVersion.query(transaction)
       .where({ projectId: id, status: 'submitted' })


### PR DESCRIPTION
Add an action to the top level project that fetches the most recent draft version and marks it as submitted. Part of a larger refactor of project submission to perform all necessary actions on a single API request.

Leaves the existing project-version submit action in place for backwards compatibility, but that should be removed eventually.