### PR TITLE
Avoid manipulating issue date when updating projects

### DIFF
--- a/lib/resolvers/project.js
+++ b/lib/resolvers/project.js
@@ -65,11 +65,12 @@ module.exports = ({ models }) => ({ action, data, id, meta }, transaction) => {
         const project = Project.query(transaction).findById(id).then(project => project);
         return Promise.all([project, generateLicenceNumber(Project, transaction, 'project', project.schemaVersion)])
           .then(([project, licenceNumber]) => {
-            const startDate = project.issueDate ? moment(project.issueDate) : moment();
-            const expiryDate = startDate.add({ months, years }).toISOString();
+            const start = project.issueDate ? moment(project.issueDate) : moment();
+            const issueDate = start.toISOString();
+            const expiryDate = start.add({ months, years }).toISOString();
             return project.$query(transaction).patchAndFetch({
               status: 'active',
-              issueDate: startDate.toISOString(),
+              issueDate,
               expiryDate,
               title: version.data.title,
               licenceNumber: project.licenceNumber || licenceNumber


### PR DESCRIPTION
We _think_ that the call to `moment.add` is modifying the `issueDate` as well. By extracting the `issueDate` as a string before modifying then we can prevent this.