### PR TITLE
Fix place creation with no NACWO

### DIFF
--- a/lib/resolvers/place.js
+++ b/lib/resolvers/place.js
@@ -9,9 +9,12 @@ module.exports = ({ models }) => ({ action, data = {}, id }, transaction) => {
   const nacwo = data.nacwo;
 
   const getNacwoId = profileId => {
-    return Role.query()
-      .findOne({ establishmentId: data.establishmentId, profileId, type: 'nacwo' })
-      .then(role => role.id);
+    if (profileId) {
+      return Role.query(transaction)
+        .findOne({ establishmentId: data.establishmentId, profileId, type: 'nacwo' })
+        .then(role => role.id);
+    }
+    return Promise.resolve(null);
   };
 
   if (action === 'create' || action === 'update') {

--- a/test/resolvers/place.js
+++ b/test/resolvers/place.js
@@ -74,6 +74,31 @@ describe('Place resolver', () => {
         });
     });
 
+    it('can insert a place model with no NACWO', () => {
+      const opts = {
+        action: 'create',
+        data: {
+          establishmentId: 8201,
+          name: 'Another room',
+          site: 'Another site',
+          suitability: JSON.stringify(['SA']),
+          holding: JSON.stringify(['NOH']),
+          nacwo: ''
+        }
+      };
+      return Promise.resolve()
+        .then(() => this.place(opts))
+        .then(() => this.models.Place.query())
+        .then(places => places[0])
+        .then(place => {
+          assert.ok(place);
+          assert.deepEqual(place.name, opts.data.name);
+          assert.deepEqual(place.site, opts.data.site);
+          assert.deepEqual(place.suitability, JSON.parse(opts.data.suitability));
+          assert.deepEqual(place.holding, JSON.parse(opts.data.holding));
+        });
+    });
+
     it('can reject an invalid place model', () => {
       const opts = {
         action: 'create',


### PR DESCRIPTION
Place creation is failing when no NACWO is defined because we try to do a database lookup with an empty id.

Check that the profile id of the NACWO is defined before trying to find an associated role record.