### PR TITLE
Allow place creation with no NACWO

### DIFF
--- a/lib/resolvers/place.js
+++ b/lib/resolvers/place.js
@@ -29,8 +29,11 @@ module.exports = ({ models }) => ({ action, data = {}, id }, transaction) => {
   }
 
   if (action === 'create') {
-    return getNacwoId(nacwo)
-      .then(nacwoId => Place.query(transaction).insert({ ...data, nacwoId }).returning('*'));
+    if (nacwo) {
+      return getNacwoId(nacwo)
+        .then(nacwoId => Place.query(transaction).insert({ ...data, nacwoId }).returning('*'));
+    }
+    return Place.query(transaction).insert(data).returning('*');
   }
 
   if (action === 'update') {


### PR DESCRIPTION
The validation requiring a NACWO was removed in the UI, which now means that approved area additions are coming in with no NACWO assigned. They currently fail when being processed by ASRU.