### PR TITLE
Don't save patch data to changelog on project edits

### DIFF
--- a/lib/resolvers/project-version.js
+++ b/lib/resolvers/project-version.js
@@ -63,7 +63,7 @@ module.exports = ({ models }) => ({ action, data, id }, transaction) => {
               return project.$query(transaction).patchAndFetch({ title });
             }
           })
-          .then(() => (action === 'patch' ? { ...data, id } : { id }));
+          .then(() => ({ id }));
       });
   }
   return resolver({ Model: ProjectVersion, action, data, id }, transaction);


### PR DESCRIPTION
Storing the complete patch object on every project version write is using up _a lot_ of data for data we dont actually need.

Specifically the changelog table is currently 15gb of data.