### PR TITLE
Flatten log json

### DIFF
--- a/lib/worker.js
+++ b/lib/worker.js
@@ -42,7 +42,7 @@ module.exports = settings => {
         if (!body.model || !resolvers[body.model]) {
           throw new Error(`Unknown model type: ${body.model}`);
         }
-        settings.logger.info('Received message', { body: message.body });
+        settings.logger.info('Received message', message.body);
         const resolver = resolvers[body.model];
         return models.transaction()
           .then(transaction => {
@@ -60,7 +60,7 @@ module.exports = settings => {
         const err = {
           message: e.message,
           stack: e.stack,
-          body: message.body
+          ...message.body
         };
         settings.logger.error(err);
         statsd.increment('asl-resolver.error');


### PR DESCRIPTION
Apparently the `body` property causes some issues downstream with ES which is why the logs from prod are not appearing correctly.

Flatten the JSON structure to get rid of the `body`.