### PR TITLE
Add a default message body in log error function

### DIFF
--- a/lib/changelog/index.js
+++ b/lib/changelog/index.js
@@ -26,7 +26,7 @@ module.exports = Changelog => {
       return Changelog.query(transaction).insert(changes);
     },
 
-    logError: (messageId, body, error) => {
+    logError: (messageId, body = {}, error) => {
       let establishmentId = body.establishmentId || (body.data && body.data.establishmentId) || null;
 
       if (establishmentId) {


### PR DESCRIPTION
If the loading of the message from S3 fails then there will be no body, and so any attempt to write an error will throw another error.