### PR TITLE
Handle missing changedBy value in project resolver

### DIFF
--- a/lib/resolvers/project.js
+++ b/lib/resolvers/project.js
@@ -3,7 +3,7 @@ const moment = require('moment');
 const resolver = require('./base-resolver');
 const { generateLicenceNumber } = require('../utils');
 
-module.exports = ({ models }) => async ({ action, data, id, meta }, transaction) => {
+module.exports = ({ models }) => async ({ action, data, id, meta = {} }, transaction) => {
   const { Project, ProjectVersion, Profile } = models;
 
   const fork = preserveStatus => {
@@ -12,17 +12,23 @@ module.exports = ({ models }) => async ({ action, data, id, meta }, transaction)
       fields = [...fields, 'status'];
     }
     return Promise.resolve()
-      .then(() => Profile.query(transaction).findById(meta.changedBy))
+      .then(() => getProfile(meta.changedBy))
       .then(profile => {
+        const asruVersion = !!(profile && profile.asruUser);
         return ProjectVersion.query(transaction)
           .where({ projectId: id })
           .orderBy('createdAt', 'desc')
           .first()
           .then(version => ProjectVersion.query(transaction).insertAndFetch({
             ...pick(version, fields),
-            asruVersion: !!profile.asruUser
+            asruVersion
           }));
       });
+  };
+
+  const getProfile = (id) => {
+    if (!id) return Promise.resolve();
+    return Profile.query(transaction).findById(id);
   };
 
   const getMostRecentVersion = (status) => {

--- a/test/resolvers/project.js
+++ b/test/resolvers/project.js
@@ -209,6 +209,20 @@ describe('Project resolver', () => {
           assert.equal(version.asruVersion, false);
         });
     });
+
+    it('sets the asruVersion flag to false if no changedBy is found', () => {
+      const opts = {
+        action: 'fork',
+        id: projectToForkId
+      };
+      return Promise.resolve()
+        .then(() => this.project(opts))
+        .then(() => this.models.ProjectVersion.query().where({ projectId: projectToForkId }).limit(1).orderBy('createdAt', 'desc'))
+        .then(versions => versions[0])
+        .then(version => {
+          assert.equal(version.asruVersion, false);
+        });
+    });
   });
 
   describe('grant', () => {


### PR DESCRIPTION
This defaults the `asruVersion` property on a project vesion to false if no `meta.changedBy` is provided for backwards compatibility.