### PR TITLE
Bugfix - dont update asruVersion flag unless granted

### DIFF
--- a/lib/resolvers/project.js
+++ b/lib/resolvers/project.js
@@ -7,23 +7,31 @@ module.exports = ({ models }) => async ({ action, data, id, meta = {} }, transac
   const { Project, ProjectVersion, Profile } = models;
 
   const fork = preserveStatus => {
-    let fields = ['data', 'projectId'];
+    let fields = ['data', 'projectId', 'asruVersion'];
     if (preserveStatus) {
       fields = [...fields, 'status'];
     }
     return Promise.resolve()
-      .then(() => getProfile(meta.changedBy))
-      .then(profile => {
-        const asruVersion = !!(profile && profile.asruUser);
+      .then(() => {
         return ProjectVersion.query(transaction)
           .where({ projectId: id })
           .orderBy('createdAt', 'desc')
-          .first()
-          .then(version => ProjectVersion.query(transaction).insertAndFetch({
-            ...pick(version, fields),
-            asruVersion
-          }));
-      });
+          .first();
+      })
+      .then(version => {
+        if (version.status === 'granted') {
+          return Promise.resolve()
+            .then(() => getProfile(meta.changedBy))
+            .then(profile => {
+              return {
+                ...version,
+                asruVersion: !!(profile && profile.asruUser)
+              };
+            });
+        }
+        return version;
+      })
+      .then(version => ProjectVersion.query(transaction).insertAndFetch(pick(version, fields)));
   };
 
   const getProfile = (id) => {

--- a/test/resolvers/project.js
+++ b/test/resolvers/project.js
@@ -193,6 +193,24 @@ describe('Project resolver', () => {
         });
     });
 
+    it('doesn\'t update the asruVersion flag is status is not granted', () => {
+      const opts = {
+        action: 'fork',
+        id: projectToForkId,
+        meta: {
+          changedBy: licensingId
+        }
+      };
+      return Promise.resolve()
+        .then(() => this.models.ProjectVersion.query().where({ projectId: projectToForkId }).patch({ status: 'draft' }))
+        .then(() => this.project(opts))
+        .then(() => this.models.ProjectVersion.query().where({ projectId: projectToForkId }).limit(1).orderBy('createdAt', 'desc'))
+        .then(versions => versions[0])
+        .then(version => {
+          assert.equal(version.asruVersion, false);
+        });
+    });
+
     it('sets the asruVersion flag to false if submitted by establishment user', () => {
       const opts = {
         action: 'fork',

--- a/test/resolvers/project.js
+++ b/test/resolvers/project.js
@@ -193,7 +193,7 @@ describe('Project resolver', () => {
         });
     });
 
-    it('doesn\'t update the asruVersion flag is status is not granted', () => {
+    it('doesn\'t update the asruVersion flag if status is not granted', () => {
       const opts = {
         action: 'fork',
         id: projectToForkId,


### PR DESCRIPTION
* We want to preserve the asruVersion status for the life of an amendment, therefore only update asruVersion flag on fork if version if granted