### PR TITLE
Send zero error metric to sysdig on success

### DIFF
--- a/lib/worker.js
+++ b/lib/worker.js
@@ -55,6 +55,8 @@ module.exports = settings => {
               });
           });
       })
+      // send a zero error metric
+      .then(() => statsd.increment('asl-resolver.error', 0))
       .then(() => done())
       .catch(e => {
         return Promise.resolve()


### PR DESCRIPTION
This allows the error rate metric to revert to zero and resolve error alerts.