### PR TITLE
Don't update issue date on PIL amendments

### DIFF
--- a/lib/resolvers/pil.js
+++ b/lib/resolvers/pil.js
@@ -37,10 +37,11 @@ module.exports = ({ models }) => async ({ action, data, id, changedBy }, transac
     const licenceNumber = await generateLicenceNumber(PIL, transaction, 'pil');
     const pil = await PIL.query(transaction).findById(id);
     const profile = await Profile.query(transaction).findById(changedBy);
+    const issueDate = pil.status === 'active' ? pil.issueDate : new Date().toISOString();
 
     const patch = {
       status: 'active',
-      issueDate: new Date().toISOString(),
+      issueDate,
       licenceNumber: pil.licenceNumber || licenceNumber,
       species: data.species,
       procedures: data.procedures,
@@ -49,7 +50,7 @@ module.exports = ({ models }) => async ({ action, data, id, changedBy }, transac
     };
 
     if (!profile.asruUser) {
-      patch.reviewDate = moment(patch.issueDate).add(5, 'years').toISOString();
+      patch.reviewDate = moment().add(5, 'years').toISOString();
     }
 
     return pil.$query(transaction).patchAndFetch(patch);


### PR DESCRIPTION
Updating a PIL resets the issue date to the current date, which is bad.

Check the status of the PIL and if it is not active then set the issue date to the current date, otherwise use the pre-existing issue date.