### PR TITLE
Create new database record if re-granting a revoked PIL

### DIFF
--- a/lib/resolvers/pil.js
+++ b/lib/resolvers/pil.js
@@ -1,4 +1,4 @@
-const { pick } = require('lodash');
+const { pick, omit } = require('lodash');
 const moment = require('moment');
 const resolver = require('./base-resolver');
 const { generateLicenceNumber } = require('../utils');
@@ -37,8 +37,21 @@ module.exports = ({ models }) => async ({ action, data, id, changedBy }, transac
     const licenceNumber = await generateLicenceNumber(PIL, transaction, 'pil');
     const pil = await PIL.query(transaction).findById(id);
     const profile = await Profile.query(transaction).findById(changedBy);
-    const issueDate = pil.status === 'active' ? pil.issueDate : new Date().toISOString();
 
+    if (pil.status === 'revoked') {
+      return PIL.query(transaction).insert({
+        ...omit(pil, 'id', 'revocationDate'),
+        status: 'active',
+        issueDate: moment().toISOString(),
+        reviewDate: moment().add(5, 'years').toISOString(),
+        species: data.species,
+        procedures: data.procedures,
+        notesCatD: data.notesCatD,
+        notesCatF: data.notesCatF
+      });
+    }
+
+    const issueDate = pil.status === 'active' ? pil.issueDate : moment().toISOString();
     const patch = {
       status: 'active',
       issueDate,


### PR DESCRIPTION
This allows the issue dates and revocation dates to be correctly preserved when a PIL is revoked and re-granted several times.