### PR TITLE
Store empty protocols array when creating the stub

### DIFF
--- a/lib/resolvers/project.js
+++ b/lib/resolvers/project.js
@@ -98,6 +98,7 @@ module.exports = ({ models }) => async ({ action, data, id, meta = {} }, transac
           status: 'granted',
           data: {
             ...version.data,
+            protocols: [],
             isLegacyStub: true // initial stub version will always have isLegacyStub: true
           }
         }


### PR DESCRIPTION
Some bits of the UI rely on `version.data.protocols` being an array.