### PR TITLE
Set default model type when logging an error to the changelog

### DIFF
--- a/lib/changelog/index.js
+++ b/lib/changelog/index.js
@@ -44,7 +44,7 @@ module.exports = Changelog => {
         messageId,
         changedBy,
         modelId: body.id ? body.id.toString() : null,
-        modelType: body.model,
+        modelType: body.model || 'error',
         action: 'error',
         state: error
       };


### PR DESCRIPTION
Sometimes resolver errors with an issue retrieving data from S3. In those cases the model type is undefined, and so writing the error fails because type is a required property in the changelog table.

Set a default model type of `error` when writing errors so that the error record can be inserted and workflow can detect the error immediately instead of timing out.

Also means only one error is logged, rather than an error and then another error logging the first error.