### PR TITLE
Include patch data on error if project-version patch fails

### DIFF
--- a/lib/resolvers/project-version.js
+++ b/lib/resolvers/project-version.js
@@ -16,8 +16,13 @@ module.exports = ({ models }) => ({ action, data, id }, transaction) => {
         .then(version => {
           version.data = version.data || {};
           version.data.protocols = version.data.protocols || [];
-          const newData = jsondiff.patch(version.data, data.patch);
-          return version.$query(transaction).patchAndFetch({ data: newData });
+          try {
+            const newData = jsondiff.patch(version.data, data.patch);
+            return version.$query(transaction).patchAndFetch({ data: newData });
+          } catch (e) {
+            e.patch = JSON.stringify(data.patch);
+            throw e;
+          }
         });
   };
 


### PR DESCRIPTION
One of these was failing on prod and was impossible to debug because we have no visibility of the underlying data.

Include the patch payload in the log if an error is thrown when applying patches.