### PR TITLE
Feature - pull PIL licence number to profile

### DIFF
--- a/lib/resolvers/establishment.js
+++ b/lib/resolvers/establishment.js
@@ -37,7 +37,7 @@ module.exports = ({ models }) => ({ action, data, id }, transaction) => {
 
   if (action === 'grant') {
     return Promise.resolve()
-      .then(() => generateLicenceNumber(Establishment, transaction, 'pel'))
+      .then(() => generateLicenceNumber({ model: Establishment, transaction, type: 'pel' }))
       .then(licenceNumber => {
         return Establishment.query(transaction).findById(id)
           .then(establishment => establishment.$query(transaction).patchAndFetch({

--- a/lib/resolvers/pil.js
+++ b/lib/resolvers/pil.js
@@ -34,9 +34,13 @@ module.exports = ({ models }) => async ({ action, data, id, changedBy }, transac
       }
     }
 
-    const licenceNumber = await generateLicenceNumber(PIL, transaction, 'pil');
     const pil = await PIL.query(transaction).findById(id);
     const profile = await Profile.query(transaction).findById(changedBy);
+
+    if (!profile.pilLicenceNumber) {
+      const pilLicenceNumber = await generateLicenceNumber({ model: Profile, transaction, type: 'pil', key: 'pilLicenceNumber' });
+      await profile.$query(transaction).patch({ pilLicenceNumber });
+    }
 
     if (pil.status === 'revoked') {
       return PIL.query(transaction).insert({
@@ -55,7 +59,6 @@ module.exports = ({ models }) => async ({ action, data, id, changedBy }, transac
     const patch = {
       status: 'active',
       issueDate,
-      licenceNumber: pil.licenceNumber || licenceNumber,
       species: data.species,
       procedures: data.procedures,
       notesCatD: data.notesCatD,

--- a/lib/resolvers/project.js
+++ b/lib/resolvers/project.js
@@ -175,7 +175,7 @@ module.exports = ({ models }) => async ({ action, data, id, meta = {} }, transac
 
     versionToGrant = await versionToGrant.$query(transaction).patchAndFetch({ status: 'granted', data });
 
-    const licenceNumber = await generateLicenceNumber(Project, transaction, 'project', project.schemaVersion);
+    const licenceNumber = await generateLicenceNumber({ model: Project, transaction, type: 'project', version: project.schemaVersion });
 
     const start = project.issueDate ? moment(project.issueDate) : moment();
     const issueDate = start.toISOString();

--- a/lib/utils/generate-licence-number.js
+++ b/lib/utils/generate-licence-number.js
@@ -1,6 +1,12 @@
 const crypto = require('crypto');
 
-const generateLicenceNumber = (model, transaction, type, version) => {
+const generateLicenceNumber = ({
+  model,
+  transaction,
+  type,
+  version,
+  key = 'licenceNumber'
+}) => {
   const buf = crypto.randomBytes(48).toString('hex');
   const digits = buf.replace(/[a-z]/g, '').substring(0, 8);
   let licenceNumber;
@@ -22,10 +28,10 @@ const generateLicenceNumber = (model, transaction, type, version) => {
 
   return model
     .query(transaction)
-    .findOne({ licenceNumber })
+    .findOne({ [key]: licenceNumber })
     .then(existing => {
       if (existing) {
-        return generateLicenceNumber(model, transaction, type, version);
+        return generateLicenceNumber({ model, transaction, type, version, key });
       }
       return licenceNumber;
     });

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,9 +10,9 @@
       "integrity": "sha1-0Egr+PlwqN4uGjeqbXyqEJnxUxE="
     },
     "@asl/schema": {
-      "version": "8.1.0",
-      "resolved": "https://artifactory.digital.homeoffice.gov.uk/artifactory/api/npm/npm-virtual/@asl/schema/-/@asl/schema-8.1.0.tgz",
-      "integrity": "sha1-01caSunuP2sQoFdktKC/R7/S3XA=",
+      "version": "8.1.1",
+      "resolved": "https://artifactory.digital.homeoffice.gov.uk/artifactory/api/npm/npm-virtual/@asl/schema/-/@asl/schema-8.1.1.tgz",
+      "integrity": "sha1-jFsa/jEjW6z8wxTSvEoPUHI7C1Y=",
       "requires": {
         "@asl/constants": "^0.7.1",
         "csv-stringify": "^5.4.3",
@@ -4769,18 +4769,18 @@
       }
     },
     "objection": {
-      "version": "2.2.2",
-      "resolved": "https://registry.npmjs.org/objection/-/objection-2.2.2.tgz",
-      "integrity": "sha512-+1Ap7u9NQRochzDW5/BggUlKi94JfZGTJwQJuNXo8DwmAb8czEirvxcWBcX91/MmQq0BQUJjM4RPSiZhnkkWQw==",
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/objection/-/objection-2.2.3.tgz",
+      "integrity": "sha512-uNya9GuHlNeix7H0URthVE3+CmAlXmxkU69LAcRnncLjujJ8l1YX8JCB2GVSErTYS3Oc2xneF1ZWaR/MS8r63g==",
       "requires": {
         "ajv": "^6.12.0",
         "db-errors": "^0.2.3"
       },
       "dependencies": {
         "ajv": {
-          "version": "6.12.3",
-          "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.3.tgz",
-          "integrity": "sha512-4K0cK3L1hsqk9xIb2z9vs/XU+PGJZ9PNpJRDS9YLzmNdX6jmVPfamLvTJr0aDAusnHyCHO6MjzlkAsgtqp9teA==",
+          "version": "6.12.4",
+          "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.4.tgz",
+          "integrity": "sha512-eienB2c9qVQs2KWexhkrdMLVDoIQCz5KSeLxwg9Lzk4DOfBtIK9PQwwufcsn1jjGuf9WZmqPMbGxOzfcuphJCQ==",
           "requires": {
             "fast-deep-equal": "^3.1.1",
             "fast-json-stable-stringify": "^2.0.0",
@@ -5046,9 +5046,9 @@
       "integrity": "sha512-bhlV7Eq09JrRIvo1eKngpwuqKtJnNhZdpdOlvrPrA4dxqXPjxSrbNrfnIDmTpwMyRszrcV4kU5ZA4mMsQUrjdg=="
     },
     "pg-cursor": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/pg-cursor/-/pg-cursor-2.3.0.tgz",
-      "integrity": "sha512-9vOHIWz8T3BWDfif7CDeZVjXUhRv4qOz/FDxolNBBU6AYgK2GThxOYsY6vmNJWuA61rtRrpAorO+LyX9X3o/4A=="
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/pg-cursor/-/pg-cursor-2.3.2.tgz",
+      "integrity": "sha512-6rRV1loW+A/zEgVpVj8V79YfMs21cs/wHFTQ1ADjSh61z/SPaFo1S3uCsQLvPJ7VdHL0emJFWpL/ylw0O7HvGg=="
     },
     "pg-int8": {
       "version": "1.0.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,9 +10,9 @@
       "integrity": "sha1-0Egr+PlwqN4uGjeqbXyqEJnxUxE="
     },
     "@asl/schema": {
-      "version": "8.1.1",
-      "resolved": "https://artifactory.digital.homeoffice.gov.uk/artifactory/api/npm/npm-virtual/@asl/schema/-/@asl/schema-8.1.1.tgz",
-      "integrity": "sha1-jFsa/jEjW6z8wxTSvEoPUHI7C1Y=",
+      "version": "8.2.0",
+      "resolved": "https://artifactory.digital.homeoffice.gov.uk/artifactory/api/npm/npm-virtual/@asl/schema/-/@asl/schema-8.2.0.tgz",
+      "integrity": "sha1-rBua/V6dCaY1DCMIuSeV//Clljs=",
       "requires": {
         "@asl/constants": "^0.7.1",
         "csv-stringify": "^5.4.3",
@@ -5046,9 +5046,9 @@
       "integrity": "sha512-bhlV7Eq09JrRIvo1eKngpwuqKtJnNhZdpdOlvrPrA4dxqXPjxSrbNrfnIDmTpwMyRszrcV4kU5ZA4mMsQUrjdg=="
     },
     "pg-cursor": {
-      "version": "2.3.2",
-      "resolved": "https://registry.npmjs.org/pg-cursor/-/pg-cursor-2.3.2.tgz",
-      "integrity": "sha512-6rRV1loW+A/zEgVpVj8V79YfMs21cs/wHFTQ1ADjSh61z/SPaFo1S3uCsQLvPJ7VdHL0emJFWpL/ylw0O7HvGg=="
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/pg-cursor/-/pg-cursor-2.3.3.tgz",
+      "integrity": "sha512-0hwZEd+gjDGgN42BFYOp2fVLyKUbk8jjDyO/PLU34W19shoh/qnCDAUzfa4+IhUGjAgN0r/xIT3pANT946zaFg=="
     },
     "pg-int8": {
       "version": "1.0.1",

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
   "homepage": "https://github.com/UKHomeOffice/asl-resolver#readme",
   "dependencies": {
     "@asl/constants": "^0.7.1",
-    "@asl/schema": "^8.1.0",
+    "@asl/schema": "^8.1.1",
     "aws-sdk": "^2.270.1",
     "hot-shots": "^6.8.2",
     "jsondiffpatch": "^0.4.1",

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
   "homepage": "https://github.com/UKHomeOffice/asl-resolver#readme",
   "dependencies": {
     "@asl/constants": "^0.7.1",
-    "@asl/schema": "^8.1.1",
+    "@asl/schema": "^8.2.0",
     "aws-sdk": "^2.270.1",
     "hot-shots": "^6.8.2",
     "jsondiffpatch": "^0.4.1",


### PR DESCRIPTION
* PIL licence number is now part of a profile not a pil, updated PIL resolver to set pilLicenceNumber to profile if on grant if not already set
* Updated generate-licence-number helper to take an object, with a customisable key