### PR TITLE
Merge PIL licence numbers on profile merge

### DIFF
--- a/lib/resolvers/profile.js
+++ b/lib/resolvers/profile.js
@@ -84,6 +84,27 @@ module.exports = ({ models, keycloak, emailer, logger }) => ({ action, data, id 
         ];
         return Promise.all(actions);
       })
+      .then(() => {
+        const actions = [
+          Profile.query(transaction).select('pilLicenceNumber').findById(id),
+          Profile.query(transaction).select('pilLicenceNumber').findById(data.target)
+        ];
+        return Promise.all(actions);
+      })
+      .then(([ before, after ]) => {
+        if (!after.pilLicenceNumber) {
+          return Profile.query(transaction).patch({ pilLicenceNumber: before.pilLicenceNumber }).where({ id: data.target });
+        }
+        if (before.pilLicenceNumber && after.pilLicenceNumber) {
+          return PIL.query(transaction).select('licenceNumber').where({ status: 'active', profileId: data.target }).first()
+            .then(pil => {
+              if (!pil) {
+                return;
+              }
+              return Profile.query(transaction).patch({ pilLicenceNumber: pil.licenceNumber }).where({ id: data.target });
+            });
+        }
+      })
       .then(() => logger.verbose('Mapped all actions'))
       .then(() => Profile.query(transaction).findById(data.target));
   }


### PR DESCRIPTION
Adds logic to copy the most relevant `pilLicenceNumber` to the target profile when two profiles are merged.

Where both profiles have a licence number then use the active PIL if it exists, or preserve the target profile's licence number otherwise.