### PR TITLE
Use Profile IDs for PIL fee waivers and not PILs

### DIFF
--- a/lib/resolvers/fee-waiver.js
+++ b/lib/resolvers/fee-waiver.js
@@ -3,22 +3,22 @@ module.exports = ({ models }) => ({ action, data, changedBy }, transaction) => {
   const { FeeWaiver } = models;
 
   if (action === 'create') {
-    const { establishmentId, pilId, comment } = data;
+    const { establishmentId, profileId, comment } = data;
     const year = parseInt(data.year, 10);
-    const profileId = changedBy;
-    return FeeWaiver.query(transaction).findOne({ establishmentId, pilId, year })
+    const waivedById = changedBy;
+    return FeeWaiver.query(transaction).findOne({ establishmentId, profileId, year })
       .then(result => {
         if (result) {
-          return FeeWaiver.query(transaction).findById(result.id).patch({ comment, profileId }).returning('*');
+          return FeeWaiver.query(transaction).findById(result.id).patch({ comment, waivedById }).returning('*');
         }
-        return FeeWaiver.query(transaction).insert({ establishmentId, pilId, year, comment, profileId });
+        return FeeWaiver.query(transaction).insert({ establishmentId, profileId, year, comment, waivedById });
       });
   }
 
   if (action === 'delete') {
-    const { establishmentId, pilId } = data;
+    const { establishmentId, profileId } = data;
     const year = parseInt(data.year, 10);
-    return FeeWaiver.query(transaction).delete().where({ establishmentId, pilId, year }).returning('*');
+    return FeeWaiver.query(transaction).delete().where({ establishmentId, profileId, year }).returning('*');
   }
 
   return Promise.reject(new Error(`Unknown action: ${action}`));

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,9 +10,9 @@
       "integrity": "sha1-0Egr+PlwqN4uGjeqbXyqEJnxUxE="
     },
     "@asl/schema": {
-      "version": "8.3.3",
-      "resolved": "https://artifactory.digital.homeoffice.gov.uk/artifactory/api/npm/npm-virtual/@asl/schema/-/@asl/schema-8.3.3.tgz",
-      "integrity": "sha1-PQC18Qw7yK1/vmv7oc491t/14Uk=",
+      "version": "9.0.0",
+      "resolved": "https://artifactory.digital.homeoffice.gov.uk/artifactory/api/npm/npm-virtual/@asl/schema/-/@asl/schema-9.0.0.tgz",
+      "integrity": "sha1-UdcaRZ8CFe7QOR1Gc5L9gbno1UI=",
       "requires": {
         "@asl/constants": "^0.7.1",
         "csv-stringify": "^5.4.3",
@@ -48,9 +48,9 @@
           }
         },
         "@sinonjs/samsam": {
-          "version": "5.1.0",
-          "resolved": "https://registry.npmjs.org/@sinonjs/samsam/-/samsam-5.1.0.tgz",
-          "integrity": "sha512-42nyaQOVunX5Pm6GRJobmzbS7iLI+fhERITnETXzzwDZh+TtDr/Au3yAvXVjFmZ4wEUaE4Y3NFZfKv0bV0cbtg==",
+          "version": "5.2.0",
+          "resolved": "https://registry.npmjs.org/@sinonjs/samsam/-/samsam-5.2.0.tgz",
+          "integrity": "sha512-CaIcyX5cDsjcW/ab7HposFWzV1kC++4HNsfnEdFJa7cP1QIuILAKV+BgfeqRXhcnSAc76r/Rh/O5C+300BwUIw==",
           "requires": {
             "@sinonjs/commons": "^1.6.0",
             "lodash.get": "^4.4.2",
@@ -80,14 +80,14 @@
           }
         },
         "sinon": {
-          "version": "9.0.3",
-          "resolved": "https://registry.npmjs.org/sinon/-/sinon-9.0.3.tgz",
-          "integrity": "sha512-IKo9MIM111+smz9JGwLmw5U1075n1YXeAq8YeSFlndCLhAL5KGn6bLgu7b/4AYHTV/LcEMcRm2wU2YiL55/6Pg==",
+          "version": "9.2.0",
+          "resolved": "https://registry.npmjs.org/sinon/-/sinon-9.2.0.tgz",
+          "integrity": "sha512-eSNXz1XMcGEMHw08NJXSyTHIu6qTCOiN8x9ODACmZpNQpr0aXTBXBnI4xTzQzR+TEpOmLiKowGf9flCuKIzsbw==",
           "requires": {
-            "@sinonjs/commons": "^1.7.2",
+            "@sinonjs/commons": "^1.8.1",
             "@sinonjs/fake-timers": "^6.0.1",
             "@sinonjs/formatio": "^5.0.1",
-            "@sinonjs/samsam": "^5.1.0",
+            "@sinonjs/samsam": "^5.2.0",
             "diff": "^4.0.2",
             "nise": "^4.0.4",
             "supports-color": "^7.1.0"
@@ -5046,9 +5046,9 @@
       "integrity": "sha512-bhlV7Eq09JrRIvo1eKngpwuqKtJnNhZdpdOlvrPrA4dxqXPjxSrbNrfnIDmTpwMyRszrcV4kU5ZA4mMsQUrjdg=="
     },
     "pg-cursor": {
-      "version": "2.3.3",
-      "resolved": "https://registry.npmjs.org/pg-cursor/-/pg-cursor-2.3.3.tgz",
-      "integrity": "sha512-0hwZEd+gjDGgN42BFYOp2fVLyKUbk8jjDyO/PLU34W19shoh/qnCDAUzfa4+IhUGjAgN0r/xIT3pANT946zaFg=="
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/pg-cursor/-/pg-cursor-2.4.1.tgz",
+      "integrity": "sha512-3ffxaoFFTedeBx72pKg/BwuSH26UelvUhlibIO/zxMYkroNIXt1uFOYLRvatozpi79GMpPe+kHVeIfcCIK7/Sg=="
     },
     "pg-int8": {
       "version": "1.0.1",

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
   "homepage": "https://github.com/UKHomeOffice/asl-resolver#readme",
   "dependencies": {
     "@asl/constants": "^0.7.1",
-    "@asl/schema": "^8.3.3",
+    "@asl/schema": "^9.0.0",
     "aws-sdk": "^2.270.1",
     "hot-shots": "^6.8.2",
     "jsondiffpatch": "^0.4.1",

--- a/test/resolvers/fee-waiver.js
+++ b/test/resolvers/fee-waiver.js
@@ -50,11 +50,11 @@ describe('FeeWaiver resolver', () => {
 
   describe('create', () => {
 
-    it('adds a FeeWaiver record for the PIL/establishment/year', () => {
+    it('adds a FeeWaiver record for the profile/establishment/year', () => {
       const params = {
         action: 'create',
         data: {
-          pilId: PIL_ID,
+          profileId: PROFILE_ID,
           establishmentId: 8201,
           year: 2019,
           comment: 'Test comment'
@@ -64,20 +64,20 @@ describe('FeeWaiver resolver', () => {
 
       return this.resolver(params)
         .then(() => {
-          return this.models.FeeWaiver.query().where({ pilId: PIL_ID, establishmentId: 8201, year: 2019 });
+          return this.models.FeeWaiver.query().where({ profileId: PROFILE_ID, establishmentId: 8201, year: 2019 });
         })
         .then(results => {
           assert.equal(results.length, 1);
-          assert.equal(results[0].profileId, ASRU_ID);
+          assert.equal(results[0].waivedById, ASRU_ID);
           assert.equal(results[0].comment, 'Test comment');
         });
     });
 
-    it('adds a single record if called mutiple times with the same PIL/establishment/year', () => {
+    it('adds a single record if called mutiple times with the same profile/establishment/year', () => {
       const params = {
         action: 'create',
         data: {
-          pilId: PIL_ID,
+          profileId: PROFILE_ID,
           establishmentId: 8201,
           year: 2019,
           comment: 'Test comment'
@@ -90,14 +90,14 @@ describe('FeeWaiver resolver', () => {
         .then(() => this.resolver(params))
         .then(() => this.resolver(params))
         .then(() => {
-          return this.models.FeeWaiver.query().where({ pilId: PIL_ID, establishmentId: 8201, year: 2019 });
+          return this.models.FeeWaiver.query().where({ profileId: PROFILE_ID, establishmentId: 8201, year: 2019 });
         })
         .then(results => {
           assert.equal(results.length, 1);
           assert.equal(results[0].establishmentId, 8201);
-          assert.equal(results[0].pilId, PIL_ID);
+          assert.equal(results[0].profileId, PROFILE_ID);
           assert.equal(results[0].year, 2019);
-          assert.equal(results[0].profileId, ASRU_ID);
+          assert.equal(results[0].waivedById, ASRU_ID);
           assert.equal(results[0].comment, 'Test comment');
         });
     });
@@ -106,10 +106,10 @@ describe('FeeWaiver resolver', () => {
 
   describe('delete', () => {
 
-    it('removes any existing record for the PIL/establishment/year', () => {
+    it('removes any existing record for the profile/establishment/year', () => {
       const params = {
         data: {
-          pilId: PIL_ID,
+          profileId: PROFILE_ID,
           establishmentId: 8201,
           year: 2019,
           comment: 'Test comment'
@@ -122,7 +122,7 @@ describe('FeeWaiver resolver', () => {
           return this.resolver({ ...params, action: 'create' });
         })
         .then(() => {
-          return this.models.FeeWaiver.query().where({ pilId: PIL_ID, establishmentId: 8201, year: 2019 });
+          return this.models.FeeWaiver.query().where({ profileId: PROFILE_ID, establishmentId: 8201, year: 2019 });
         })
         .then(results => {
           assert.equal(results.length, 1);
@@ -131,7 +131,7 @@ describe('FeeWaiver resolver', () => {
           return this.resolver({ ...params, action: 'delete' });
         })
         .then(() => {
-          return this.models.FeeWaiver.query().where({ pilId: PIL_ID, establishmentId: 8201, year: 2019 });
+          return this.models.FeeWaiver.query().where({ profileId: PROFILE_ID, establishmentId: 8201, year: 2019 });
         })
         .then(results => {
           assert.equal(results.length, 0);
@@ -141,7 +141,7 @@ describe('FeeWaiver resolver', () => {
     it('leaves existing record for a different year', () => {
       const params = {
         data: {
-          pilId: PIL_ID,
+          profileId: PROFILE_ID,
           establishmentId: 8201,
           comment: 'Test comment'
         },
@@ -158,7 +158,7 @@ describe('FeeWaiver resolver', () => {
           return this.resolver({ ...params, action: 'create' });
         })
         .then(() => {
-          return this.models.FeeWaiver.query().where({ pilId: PIL_ID, establishmentId: 8201 });
+          return this.models.FeeWaiver.query().where({ profileId: PROFILE_ID, establishmentId: 8201 });
         })
         .then(results => {
           assert.equal(results.length, 2);
@@ -168,11 +168,11 @@ describe('FeeWaiver resolver', () => {
           return this.resolver({ ...params, action: 'delete' });
         })
         .then(() => {
-          return this.models.FeeWaiver.query().where({ pilId: PIL_ID, establishmentId: 8201 });
+          return this.models.FeeWaiver.query().where({ profileId: PROFILE_ID, establishmentId: 8201 });
         })
         .then(results => {
           assert.equal(results.length, 1);
-          assert.equal(results[0].pilId, PIL_ID);
+          assert.equal(results[0].profileId, PROFILE_ID);
           assert.equal(results[0].establishmentId, 8201);
           assert.equal(results[0].year, 2019);
         });


### PR DESCRIPTION
A waiver applies to all related PIL records for an establishment, so use the parent profile as the key and not the PIL record.

WIP until https://github.com/UKHomeOffice/asl-schema/pull/378