### PR TITLE
Only include id and email in verification token

### DIFF
--- a/lib/resolvers/profile.js
+++ b/lib/resolvers/profile.js
@@ -6,7 +6,7 @@ module.exports = ({ models, keycloak, emailer, logger, jwt }) => ({ action, data
 
   const sendVerificationEmail = profile => {
     return Promise.resolve()
-      .then(() => jwt.sign({ ...profile, action: 'confirm-email' }))
+      .then(() => jwt.sign({ id: profile.id, email: profile.email, action: 'confirm-email' }))
       .then(token => {
         return emailer.sendEmail({ ...profile, token, template: 'confirm-email' });
       })


### PR DESCRIPTION
Since data encoded in jwt tokens can be extracted without the signing secret including the entire profile in the token could potentially leak personal data.