### PR TITLE
Copy raCompulsory flag on fork

### DIFF
--- a/lib/resolvers/project.js
+++ b/lib/resolvers/project.js
@@ -7,7 +7,7 @@ module.exports = ({ models }) => async ({ action, data, id, meta = {} }, transac
   const { Project, ProjectVersion, ProjectEstablishment, Profile, Certificate, RetrospectiveAssessment } = models;
 
   const fork = preserveStatus => {
-    let fields = ['data', 'projectId', 'asruVersion'];
+    let fields = ['data', 'projectId', 'asruVersion', 'raCompulsory'];
     if (preserveStatus) {
       fields = [...fields, 'status'];
     }

--- a/test/resolvers/project.js
+++ b/test/resolvers/project.js
@@ -166,7 +166,8 @@ describe('Project resolver', () => {
           status: 'granted',
           data: {
             title: 'Granted project'
-          }
+          },
+          raCompulsory: true
         }))
         .then(() => this.models.Profile.query().insert([
           {
@@ -249,6 +250,19 @@ describe('Project resolver', () => {
         .then(versions => versions[0])
         .then(version => {
           assert.equal(version.asruVersion, false);
+        });
+    });
+
+    it('preserves the RA compulsory flag', () => {
+      const opts = {
+        action: 'fork',
+        id: projectToForkId
+      };
+      return Promise.resolve()
+        .then(() => this.project(opts))
+        .then(() => this.models.ProjectVersion.query().where({ projectId: projectToForkId }).orderBy('createdAt', 'desc').first())
+        .then(version => {
+          assert.equal(version.raCompulsory, true);
         });
     });
   });


### PR DESCRIPTION
This was being dropped when forking projects, resulting in the RA condition going missing if an application or amendment was resubmitted without changes.