### PR TITLE
Allow ASRU user to directly grant an RA

### DIFF
--- a/lib/resolvers/project.js
+++ b/lib/resolvers/project.js
@@ -3,7 +3,7 @@ const moment = require('moment');
 const resolver = require('./base-resolver');
 const { generateLicenceNumber, normaliseProjectVersion, getSpecies } = require('../utils');
 
-module.exports = ({ models }) => async ({ action, data, id, meta = {} }, transaction) => {
+module.exports = ({ models }) => async ({ action, data, id, meta = {}, changedBy }, transaction) => {
   const { Project, ProjectVersion, ProjectEstablishment, Profile, Certificate, RetrospectiveAssessment } = models;
 
   const fork = preserveStatus => {
@@ -21,7 +21,7 @@ module.exports = ({ models }) => async ({ action, data, id, meta = {} }, transac
       .then(version => {
         if (version.status === 'granted') {
           return Promise.resolve()
-            .then(() => getProfile(meta.changedBy))
+            .then(() => getProfile(changedBy))
             .then(profile => {
               return {
                 ...version,
@@ -220,12 +220,13 @@ module.exports = ({ models }) => async ({ action, data, id, meta = {} }, transac
   if (action === 'grant-ra') {
     const raVersionToGrant = await getMostRecentVersion(null, RetrospectiveAssessment);
     const project = await Project.query(transaction).findById(id);
+    const profile = await getProfile(changedBy);
 
     if (raVersionToGrant.status === 'granted') {
       return project;
     }
 
-    if (raVersionToGrant.status !== 'submitted') {
+    if (raVersionToGrant.status !== 'submitted' && !profile.asruUser) {
       throw new Error('Cannot grant unsubmitted ra version');
     }
 


### PR DESCRIPTION
The desired behaviour for ASRU submitting retrospective assessments is for them to resolve immediately without needing to be reviewed by an inspector or licensing officer.

This means they need to bypass the check the the most recent version is submitted in order to grant, because at this point the version is `draft`.