### PR TITLE
Create additional availability associations on transferred PPLs

### DIFF
--- a/lib/resolvers/project.js
+++ b/lib/resolvers/project.js
@@ -109,6 +109,26 @@ module.exports = ({ models }) => async ({ action, data, id, meta = {}, changedBy
       );
   }
 
+  function transferAdditionalAvailability(version, projectId) {
+    const additionalEstablishmentsSelected = get(version, 'data.other-establishments', false);
+    const establishments = additionalEstablishmentsSelected
+      ? get(version, 'data.establishments', [])
+        .filter(e => e['establishment-id'])
+        .map(e => e['establishment-id'])
+      : [];
+
+    return ProjectEstablishment.query(transaction)
+      .where({ projectId })
+      .insert(establishments.map(establishmentId => {
+        return {
+          projectId,
+          establishmentId,
+          status: 'active',
+          issueDate: moment().toISOString()
+        };
+      }));
+  }
+
   const version = get(data, 'version', {});
 
   if (data) {
@@ -401,7 +421,7 @@ module.exports = ({ models }) => async ({ action, data, id, meta = {}, changedBy
       transferredInDate: transferDate
     });
 
-    await ProjectVersion.query(transaction).insert({
+    const newVersion = await ProjectVersion.query(transaction).insert({
       ...omit(versionToTransfer, 'id'),
       projectId: newProject.id,
       status: 'granted',
@@ -414,6 +434,7 @@ module.exports = ({ models }) => async ({ action, data, id, meta = {}, changedBy
       transferEstablishmentId: data.establishmentId,
       transferredOutDate: transferDate
     });
+    await transferAdditionalAvailability(newVersion, newProject.id);
     return newProject;
   }
 

--- a/lib/resolvers/project.js
+++ b/lib/resolvers/project.js
@@ -434,6 +434,9 @@ module.exports = ({ models }) => async ({ action, data, id, meta = {}, changedBy
       transferEstablishmentId: data.establishmentId,
       transferredOutDate: transferDate
     });
+    // remove draft AA records from old project
+    await ProjectEstablishment.query(transaction).where({ projectId: id, status: 'draft' }).delete();
+    // create new AA records on new project
     await transferAdditionalAvailability(newVersion, newProject.id);
     return newProject;
   }


### PR DESCRIPTION
Currently when a PPL with additional establishments is transferred the new relations are not created at the target establishment.

This means that the transferred PPL ceases to be available at it's additional establishments.