### PR TITLE
Reduce amount of data stored in last login changelog

### DIFF
--- a/lib/resolvers/profile.js
+++ b/lib/resolvers/profile.js
@@ -15,7 +15,9 @@ module.exports = ({ models, keycloak, emailer, logger, jwt }) => ({ action, data
   };
 
   if (action === 'updateLastLogin') {
-    return Profile.query(transaction).patchAndFetchById(id, { lastLogin: moment().toISOString() });
+    const patch = { lastLogin: moment().toISOString() };
+    return Profile.query(transaction).patchAndFetchById(id, patch)
+      .then(() => patch);
   }
 
   if (action === 'create') {


### PR DESCRIPTION
Only need the bare minimum not to save the entire profile. This will reduce the amount of disk space used in the longer term.