### PR TITLE
Update project versions on profile merge

### DIFF
--- a/lib/resolvers/profile.js
+++ b/lib/resolvers/profile.js
@@ -3,7 +3,16 @@ const resolver = require('./base-resolver');
 
 module.exports = ({ models, keycloak, emailer, logger, jwt }) => ({ action, data, id }, transaction) => {
 
-  const { Profile, Project, PIL, Permission, Role, Certificate, Exemption } = models;
+  const {
+    Profile,
+    Project,
+    ProjectVersion,
+    PIL,
+    Permission,
+    Role,
+    Certificate,
+    Exemption
+  } = models;
 
   const sendVerificationEmail = profile => {
     return Promise.resolve()
@@ -100,6 +109,7 @@ module.exports = ({ models, keycloak, emailer, logger, jwt }) => ({ action, data
       .then(() => {
         const actions = [
           Project.query(transaction).patch({ licenceHolderId: data.target }).where({ licenceHolderId: id }),
+          ProjectVersion.query(transaction).patch({ licenceHolderId: data.target }).where({ licenceHolderId: id }),
           PIL.query(transaction).patch({ profileId: data.target }).where({ profileId: id }),
           Certificate.query(transaction).patch({ profileId: data.target }).where({ profileId: id }),
           Exemption.query(transaction).patch({ profileId: data.target }).where({ profileId: id })


### PR DESCRIPTION
The licence holder id is stored on project versions now as well as projects, so when profiles are merged and the projects are updated we need to also move the versions.