### PR TITLE
Don't allow revocation of expired projects

### DIFF
--- a/lib/resolvers/project.js
+++ b/lib/resolvers/project.js
@@ -493,6 +493,12 @@ module.exports = ({ models }) => async ({ action, data, id, meta = {}, changedBy
   }
 
   if (action === 'revoke') {
+    const project = await Project.query(transaction).findById(id);
+
+    if (project.status !== 'active') {
+      throw new Error('Cannot revoke non-active projects');
+    }
+
     const latestVersion = await getMostRecentVersion('granted');
     const revocationDate = new Date().toISOString();
 


### PR DESCRIPTION
Had a question from ASRU about a revocation request for a project that had expired while the task was open and what the effects of resolving the task would be.

As a result, make it not possible to revoke projects that are already expired.