### PR TITLE
Fix place role assignments

### DIFF
--- a/lib/resolvers/place.js
+++ b/lib/resolvers/place.js
@@ -54,12 +54,17 @@ module.exports = ({ models }) => async ({ action, data = {}, id }, transaction) 
   if (action === 'update') {
     const place = await Place.query(transaction).patchAndFetchById(id, data);
 
+    const allRoles = await Role.query(transaction).select('id').where({ establishmentId: place.establishmentId });
+
     const existingRoles = await Role.query(transaction)
       .join('placeRoles', 'roles.id', '=', 'placeRoles.roleId')
       .where('placeRoles.placeId', id)
       .whereNull('placeRoles.deleted');
 
-    const newRoles = requestedRoles.filter(roleId => !existingRoles.find(r => r.id === roleId));
+    const newRoles = requestedRoles
+      .filter(roleId => allRoles.find(r => r.id === roleId))
+      .filter(roleId => !existingRoles.find(r => r.id === roleId));
+
     const removedRoles = existingRoles.filter(r => !requestedRoles.includes(r.id)).map(r => r.id);
 
     await PlaceRole.query(transaction).where({ placeId: id }).whereIn('roleId', removedRoles).delete(); // soft delete

--- a/lib/resolvers/role.js
+++ b/lib/resolvers/role.js
@@ -4,7 +4,7 @@ module.exports = ({ models }) => ({ action, data, id }, transaction) => {
     'holc'
   ];
 
-  const { Role, Establishment, Place, Profile } = models;
+  const { Role, Establishment, PlaceRole, Profile } = models;
   const {
     establishmentId,
     profileId,
@@ -12,14 +12,10 @@ module.exports = ({ models }) => ({ action, data, id }, transaction) => {
     role
   } = data;
 
-  const dissociateNacwo = (establishmentId, type) => {
-    if (type !== 'nacwo') {
-      return Promise.resolve();
-    }
-
-    return Place.query(transaction)
-      .where({ establishmentId, nacwoId: id })
-      .patch({ nacwoId: null });
+  const dissociatePlaces = (establishmentId, type) => {
+    return PlaceRole.query(transaction)
+      .where({ roleId: id })
+      .delete();
   };
 
   const touchEstablishment = (id, type) => {
@@ -62,7 +58,7 @@ module.exports = ({ models }) => ({ action, data, id }, transaction) => {
         typeOfDeletedRole = role.type;
         return role.$query().delete();
       })
-      .then(() => dissociateNacwo(establishmentId, typeOfDeletedRole))
+      .then(() => dissociatePlaces(establishmentId, typeOfDeletedRole))
       .then(() => touchEstablishment(establishmentId, typeOfDeletedRole))
       .then(() => Role.queryWithDeleted(transaction).findById(id));
   }

--- a/test/resolvers/place.js
+++ b/test/resolvers/place.js
@@ -267,6 +267,32 @@ describe('Place resolver', () => {
             nowish(establishment.updatedAt, new Date().toISOString());
           });
       });
+
+      it('removes any roles that are missing from the establishment', () => {
+        const opts = {
+          action: 'update',
+          id: PLACE_ID1,
+          data: {
+            name: 'A room',
+            site: 'A site',
+            suitability: ['SA'],
+            holding: ['NOH'],
+            roles: [
+              NACWO_ROLE_ID_1,
+              NACWO_ROLE_ID_2
+            ]
+          }
+        };
+        return Promise.resolve()
+          .then(() => this.models.Role.query().findById(NACWO_ROLE_ID_1).delete())
+          .then(() => this.place(opts))
+          .then(() => this.models.Place.query().findById(PLACE_ID1).withGraphFetched('roles'))
+          .then(place => {
+            assert.ok(place);
+            assert.equal(place.roles.length, 1);
+            assert.equal(place.roles[0].id, NACWO_ROLE_ID_2);
+          });
+      });
     });
 
     describe('Delete', () => {


### PR DESCRIPTION
Two issues, each addressed in it's own commit:

1. Places were not being correctly disassociated from NVS and NACWOs when those roles were removed - update the code to correctly remove the relations.
2. In flight place amendments with NVS and NACWOs that were removed while the task was open could not be resolved because they tried to re-add the role, which did not exist. Add a filter to the `newRoles` so that only roles which exist on the establishment at the time of resolution are included.