### PR TITLE
Clean project additional establishments on grant

### DIFF
--- a/lib/resolvers/project.js
+++ b/lib/resolvers/project.js
@@ -83,6 +83,20 @@ module.exports = ({ models }) => async ({ action, data, id, meta = {}, changedBy
     return null;
   }
 
+  function cleanVersionData(version) {
+    const data = version.data;
+    data.protocols = (data.protocols || []).filter(p => !p.deleted);
+    removeDeletedConditions(data);
+    data.protocols.forEach(removeDeletedConditions);
+
+    // remove additional establishments data if granting without any AA selected
+    const additionalEstablishmentsSelected = get(version, 'data.other-establishments', false);
+    if (!additionalEstablishmentsSelected) {
+      data.establishments = [];
+    }
+    return omit(data, 'transferToEstablishment');
+  }
+
   function setAdditionalAvailability(version) {
     const additionalEstablishmentsSelected = get(version, 'data.other-establishments', false);
     const establishments = additionalEstablishmentsSelected
@@ -278,13 +292,9 @@ module.exports = ({ models }) => async ({ action, data, id, meta = {}, changedBy
       throw new Error('Cannot grant unsubmitted version');
     }
 
-    const data = versionToGrant.data;
-    data.protocols = (data.protocols || []).filter(p => !p.deleted);
-
-    removeDeletedConditions(data);
-    data.protocols.forEach(removeDeletedConditions);
-
     await setAdditionalAvailability(versionToGrant);
+
+    const data = cleanVersionData(versionToGrant);
 
     versionToGrant = await versionToGrant.$query(transaction).patchAndFetch({ status: 'granted', data });
 
@@ -453,7 +463,7 @@ module.exports = ({ models }) => async ({ action, data, id, meta = {}, changedBy
       ...omit(versionToTransfer, 'id'),
       projectId: newProject.id,
       status: 'granted',
-      data: omit(versionToTransfer.data, 'transferToEstablishment')
+      data: cleanVersionData(versionToTransfer)
     });
 
     await project.$query(transaction).patch({

--- a/test/resolvers/project.js
+++ b/test/resolvers/project.js
@@ -1121,6 +1121,39 @@ describe('Project resolver', () => {
         });
     });
 
+    it('removes establishments if additional establishments is set to false', () => {
+      const opts = {
+        action: 'grant',
+        id: projectId
+      };
+      const versionId = generateUuid();
+      const version = {
+        id: versionId,
+        projectId,
+        status: 'submitted',
+        data: {
+          'other-establishments': false,
+          establishments: [
+            {
+              'establishment-id': 100
+            },
+            {
+              'establishment-id': 101
+            }
+          ]
+        }
+      };
+
+      return Promise.resolve()
+        .then(() => this.models.ProjectVersion.query().insert(version))
+        .then(() => this.project(opts))
+        .then(() => this.models.ProjectVersion.query().findById(versionId))
+        .then(version => {
+          assert.deepStrictEqual(version.data.establishments, []);
+        });
+
+    });
+
     it('resolves if project version is already granted', () => {
       const opts = {
         action: 'grant',


### PR DESCRIPTION
If an applicant has selected "No" for their PPL having additional establishments then remove any nested data for the establishments at the point of granting.

This prevents any issues if a PPL holder has establishment affiliations removed but the association from the project being partially revived if additional establishments later switched to "Yes".

Also ensure that the same process is included in a transfer resolution as transfers and amendments are equivalent.