### PR TITLE
Split sync of training and submission to ASRU

### DIFF
--- a/lib/resolvers/project.js
+++ b/lib/resolvers/project.js
@@ -260,13 +260,22 @@ module.exports = ({ models }) => async ({ action, data, id, meta = {}, changedBy
       return project;
     }
 
-    const training = await Certificate.query(transaction).where({ profileId: project.licenceHolderId });
-    await version.$query(transaction).patchAndFetch({ status: 'submitted', data: { ...version.data, training } });
+    await version.$query(transaction).patchAndFetch({ status: 'submitted' });
 
     if (project.status === 'inactive') {
       const species = getSpecies(version.data, project);
       await project.$query(transaction).patchAndFetch({ species: species.length ? species : null });
     }
+
+    return project;
+  }
+
+  if (action === 'sync-training') {
+    const version = await getMostRecentVersion('draft');
+    const project = await Project.query(transaction).findById(id);
+
+    const training = await Certificate.query(transaction).where({ profileId: project.licenceHolderId });
+    await version.$query(transaction).patchAndFetch({ data: { ...version.data, training } });
 
     return project;
   }


### PR DESCRIPTION
The addition of the training data needs to be done at the point of submission for endorsement so that it is available to the admin user reviewing the project for endorsement.

To be able to do this separately from the status update of the version it needs to be split into a separate action from `submit-draft` which is called only after endorsement.