### PR TITLE
Update sqs-consumer implementation

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,4 +1,4 @@
-const Consumer = require('sqs-consumer');
+const { Consumer } = require('sqs-consumer');
 const AWS = require('aws-sdk');
 const config = require('./config');
 

--- a/lib/worker.js
+++ b/lib/worker.js
@@ -25,9 +25,9 @@ module.exports = settings => {
 
   const changelog = Changelog(models.Changelog);
 
-  return (message, done) => {
+  return (message) => {
     const start = performance.now();
-    Promise.resolve()
+    return Promise.resolve()
       .then(() => {
         return JSON.parse(message.Body);
       })
@@ -58,7 +58,6 @@ module.exports = settings => {
         statsd.increment('asl-resolver.processed', 1);
         settings.logger.info('Processed message', { ...message.body, time });
       })
-      .then(() => done())
       .catch(e => {
         return Promise.resolve()
           .then(() => {
@@ -74,8 +73,7 @@ module.exports = settings => {
           })
           .catch(e => {
             settings.logger.error({ ...e, message: e.message, stack: e.stack });
-          })
-          .then(() => done());
+          });
       });
 
   };


### PR DESCRIPTION
The major version bump of `sqs-consumer` changes the module structure and method signature slightly - most significantly to use promises/async-await instead of callbacks.