### PR TITLE
Remove deleted additional establishments from draft PPLs

### DIFF
--- a/lib/resolvers/project-version.js
+++ b/lib/resolvers/project-version.js
@@ -17,6 +17,7 @@ module.exports = ({ models }) => async ({ action, data, id }, transaction) => {
 
     const establishments = additionalEstablishmentsSelected
       ? get(version, 'data.establishments', [])
+        .filter(e => !e.deleted)
         .filter(e => e['establishment-id'])
         .map(e => e['establishment-id'])
       : [];

--- a/test/resolvers/project-version.js
+++ b/test/resolvers/project-version.js
@@ -279,6 +279,23 @@ describe('ProjectVersion resolver', () => {
             assert.equal(projectEstablishment, null);
           });
       });
+
+      it('removes draft ProjectEstablishment relations if establishments are marked as deleted', () => {
+        const opts = {
+          action: 'patch',
+          id: versionId,
+          data: {
+            patch: jsondiff.diff({}, { establishments: [{ 'establishment-id': 8202, deleted: true }], 'other-establishments': true })
+          }
+        };
+        return Promise.resolve()
+          .then(() => this.models.ProjectEstablishment.query().insert({ establishmentId: 8202, projectId, status: 'draft' }))
+          .then(() => this.projectVersion(opts))
+          .then(() => this.models.ProjectEstablishment.query().where({ establishmentId: 8202, projectId }).first())
+          .then(projectEstablishment => {
+            assert.equal(projectEstablishment, null);
+          });
+      });
     });
 
   });


### PR DESCRIPTION
When a draft PPL has an additional establishment removed it doesn't delete it from the version data, only sets a deleted flag.

However it should be removed from the relation table so it doesn't appear as an additional establishment on project landing pages, or ask for AWERB details when submitting.

Integration test at https://github.com/UKHomeOffice/asl-deployments/pull/1308