### PR TITLE
Only reminders with deadlines need saving/deleting

### DIFF
--- a/lib/utils/extract-reminders.js
+++ b/lib/utils/extract-reminders.js
@@ -30,7 +30,7 @@ const extractReminders = (version, conditions) => {
       const active = condition.reminders.active || [];
       const conditionKey = Object.keys(condition.reminders).filter(k => k !== 'active')[0];
 
-      condition.reminders[conditionKey].map(item => {
+      condition.reminders[conditionKey].filter(item => item.deadline).map(item => {
         reminders.push({
           ...pick(item, ['id', 'deadline']),
           modelType: 'project',


### PR DESCRIPTION
if a reminder object is passed without a deadline then it was never previously saved, and can be safely ignored