### PR TITLE
Handle case where reminders is undefined

### DIFF
--- a/lib/utils/extract-reminders.js
+++ b/lib/utils/extract-reminders.js
@@ -29,7 +29,9 @@ const extractReminders = (version, conditions) => {
     .reduce((reminders, condition) => {
       const active = condition.reminders.active || [];
       const conditionKey = Object.keys(condition.reminders).filter(k => k !== 'active')[0];
-
+      if (!condition.reminders[conditionKey]) {
+        return reminders;
+      }
       condition.reminders[conditionKey].filter(item => item.deadline).map(item => {
         reminders.push({
           ...pick(item, ['id', 'deadline']),


### PR DESCRIPTION
This is throwing errors in production due to `condition.reminders[conditionKey]` being undefined. If that is the case allow the `reduce` to continue instead of throwing errors.