### PR TITLE
Preserve PEL updated at timestamp when editing billing data

### DIFF
--- a/lib/resolvers/establishment.js
+++ b/lib/resolvers/establishment.js
@@ -38,7 +38,7 @@ module.exports = ({ models }) => async ({ action, data, id }, transaction) => {
 
   if (action === 'update-billing') {
     data = { billing: { ...data, updatedAt: new Date().toISOString() } };
-    action = 'update';
+    return Establishment.query(transaction).context({ preserveUpdatedAt: true }).patchAndFetchById(id, data);
   }
 
   if (action === 'grant') {

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "MIT",
       "dependencies": {
         "@asl/constants": "^1.2.1",
-        "@asl/schema": "^10.11.0",
+        "@asl/schema": "^10.12.0",
         "@asl/service": "^8.10.0",
         "aws-sdk": "^2.814.0",
         "hot-shots": "^6.8.2",
@@ -129,9 +129,9 @@
       "license": "MIT"
     },
     "node_modules/@asl/schema": {
-      "version": "10.11.0",
-      "resolved": "https://artifactory.digital.homeoffice.gov.uk/artifactory/api/npm/npm-virtual/@asl/schema/-/@asl/schema-10.11.0.tgz",
-      "integrity": "sha512-xNP6g1YEtV9fjgSHc7FhcLvjebsJySXkMakqlgbyNHaN6QbK+YOdKUpj/Kogz33ilimnfeKwosU8LsdmGmehkQ==",
+      "version": "10.12.0",
+      "resolved": "https://artifactory.digital.homeoffice.gov.uk/artifactory/api/npm/npm-virtual/@asl/schema/-/@asl/schema-10.12.0.tgz",
+      "integrity": "sha512-oix6wjOU8jHBYTyaJkTvG9nhSUPgsXaZtkuc+i6s0iza8s6kVvD2OStqE2kL5RsPzldyXhgyK4dxsga3lXi18Q==",
       "license": "MIT",
       "dependencies": {
         "@asl/constants": "^1.1.1",
@@ -14416,9 +14416,9 @@
       "integrity": "sha1-zAfMVkySkCf0sdfp7o0vVEv5KLs="
     },
     "@asl/schema": {
-      "version": "10.11.0",
-      "resolved": "https://artifactory.digital.homeoffice.gov.uk/artifactory/api/npm/npm-virtual/@asl/schema/-/@asl/schema-10.11.0.tgz",
-      "integrity": "sha512-xNP6g1YEtV9fjgSHc7FhcLvjebsJySXkMakqlgbyNHaN6QbK+YOdKUpj/Kogz33ilimnfeKwosU8LsdmGmehkQ==",
+      "version": "10.12.0",
+      "resolved": "https://artifactory.digital.homeoffice.gov.uk/artifactory/api/npm/npm-virtual/@asl/schema/-/@asl/schema-10.12.0.tgz",
+      "integrity": "sha512-oix6wjOU8jHBYTyaJkTvG9nhSUPgsXaZtkuc+i6s0iza8s6kVvD2OStqE2kL5RsPzldyXhgyK4dxsga3lXi18Q==",
       "requires": {
         "@asl/constants": "^1.1.1",
         "audit-ci": "^5.1.1",

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
   "homepage": "https://github.com/UKHomeOffice/asl-resolver#readme",
   "dependencies": {
     "@asl/constants": "^1.2.1",
-    "@asl/schema": "^10.11.0",
+    "@asl/schema": "^10.12.0",
     "@asl/service": "^8.10.0",
     "aws-sdk": "^2.814.0",
     "hot-shots": "^6.8.2",


### PR DESCRIPTION
This is causing the licence documents to have a "last amended" timestamp that does not correspond to any amendment.

~WIP pending https://github.com/UKHomeOffice/asl-schema/pull/565~