### PR TITLE
Add deleted flag to reminders when they are removed

### DIFF
--- a/lib/resolvers/project-version.js
+++ b/lib/resolvers/project-version.js
@@ -72,6 +72,16 @@ module.exports = ({ models }) => async ({ action, data, id }, transaction) => {
 
     const { protocolId, retrospectiveAssessment } = data;
     const { conditions, reminders } = extractReminders(version, data.conditions);
+    const reminderIds = reminders.map(reminder => reminder.id);
+
+    // Compares the deadlines in the state to the ones in the database, if in database but no longer in state flag as deleted
+    const remindersFromDb = await Reminder.query().where({modelId: version.projectId});
+    remindersFromDb.forEach(reminder => {
+      if (!reminderIds.includes(reminder.id)) {
+        reminder.deleted = (new Date()).toISOString();
+        reminders.push(reminder);
+      }
+    });
 
     await Promise.all(
       // extractReminders() sets a deleted prop where necessary, so upsert should handle deletions as well


### PR DESCRIPTION
Fix for [ASL-4062](https://collaboration.homeoffice.gov.uk/jira/browse/ASL-4062)

Compares the reminders in the submission to the reminders in the database for each condition
If a reminder has been removed (ie in the database but not in the submission) add the deleted flag to the reminder