### PR TITLE
ASL-4052 - Add replace action for role

### DIFF
--- a/lib/resolvers/role.js
+++ b/lib/resolvers/role.js
@@ -62,6 +62,18 @@ module.exports = ({ models }) => ({ action, data, id }, transaction) => {
       .then(() => touchEstablishment(establishmentId, typeOfDeletedRole))
       .then(() => Role.queryWithDeleted(transaction).findById(id));
   }
+  if (action === 'replace') {
+    // renamed `role` to `type` - fallback for b/c
+    const typeOfRole = type || role;
+    const { replaceRoles } = data;
+    return Role.query(transaction).where({ establishmentId }).whereIn('type', replaceRoles).delete()
+      .then(() => {
+        return Role.query(transaction)
+          .insert({ establishmentId, profileId, type: typeOfRole })
+          .returning('*');
+      })
+      .then(result => touchEstablishment(establishmentId, typeOfRole).then(() => result));
+  }
 
   return Promise.reject(new Error(`Unknown action: ${action}`));
 

--- a/test/resolvers/role.js
+++ b/test/resolvers/role.js
@@ -9,6 +9,7 @@ const PROFILE_ID_2 = uuid();
 const PROFILE_ID_3 = uuid();
 const ROLE_ID = uuid();
 const HOLC_ROLE_ID = uuid();
+const PELH_ROLE_ID = uuid();
 
 const NACWO_ROLE_ID = uuid();
 const NACWO_ROLE_ID_2 = uuid();
@@ -102,6 +103,12 @@ describe('Role resolver', () => {
           establishmentId: ESTABLISHMENT_ID_2,
           profileId: PROFILE_ID_3,
           type: 'nvs'
+        },
+        {
+          id: PELH_ROLE_ID,
+          establishmentId: ESTABLISHMENT_ID,
+          profileId: PROFILE_ID,
+          type: 'pelh'
         }
       ]))
       .then(() => this.models.Place.query().insert([
@@ -336,5 +343,33 @@ describe('Role resolver', () => {
 
     });
 
+  });
+
+  describe('Replace', () => {
+
+    it('removes any existing roles and updates the establishment record', () => {
+      const opts = {
+        action: 'replace',
+        data: {
+          establishmentId: ESTABLISHMENT_ID,
+          profileId: PROFILE_ID_2,
+          type: 'nprc',
+          replaceRoles: ['nprc', 'pelh']
+        }
+      };
+      return Promise.resolve()
+        .then(() => this.role(opts))
+        .then(() => this.models.Establishment.query().findById(8201))
+        .then(establishment => {
+          assert.ok(establishment);
+          nowish(establishment.updatedAt, new Date().toISOString());
+        })
+        .then(() => this.models.Role.query().where({ establishmentId: ESTABLISHMENT_ID }).whereIn('type', ['pelh', 'nprc']))
+        .then(roles => {
+          assert.ok(roles.length === 1);
+          assert.ok(roles[0].type === 'nprc');
+          assert.ok(roles[0].profileId === PROFILE_ID_2);
+        });
+    });
   });
 });


### PR DESCRIPTION
Have used a new action type that accepts the roles being replaced in the data `replaceRoles`, that way if there are any other roles that need similar functionality in the future the additional data can be passed in.